### PR TITLE
prod ci/cd 설정 추가 및 기존 설정 수정

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -22,7 +22,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build jar with Gradle
-        run: ./gradlew clean bootJar
+        run: ./gradlew clean build
 
       - name: Rename jar to app.jar
         run: |
@@ -50,5 +50,14 @@ jobs:
               source /home/ubuntu/env.sh
               echo "SPRING_PROFILES_ACTIVE=$SPRING_PROFILES_ACTIVE"
               cd /home/ubuntu/app
+
+              # 기존 프로세스 종료
+              PID=$(pgrep -f "app.jar")
+              if [ -n "$PID" ]; then
+                echo "Killing existing process: $PID"
+                kill -9 $PID
+              fi
+
+              # 새로운 프로세스 실행
               nohup java -jar app.jar --spring.profiles.active=$SPRING_PROFILES_ACTIVE > app.log 2>&1 &
             '

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Copy app.jar to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_KEY }}
+          host: ${{ secrets.DEV_EC2_HOST }}
+          username: ${{ secrets.DEV_EC2_USER }}
+          key: ${{ secrets.DEV_EC2_KEY }}
           source: "deploy/app.jar"
           target: "/home/ubuntu/app"
           strip_components: 1
@@ -42,9 +42,9 @@ jobs:
       - name: Restart Spring Boot app on EC2
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_KEY }}
+          host: ${{ secrets.DEV_EC2_HOST }}
+          username: ${{ secrets.DEV_EC2_USER }}
+          key: ${{ secrets.DEV_EC2_KEY }}
           script: |
             bash -c '
               source /home/ubuntu/env.sh

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,63 @@
+name: Deploy to Prod EC2
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x ./gradlew
+
+      - name: Build jar with Gradle
+        run: ./gradlew clean build
+
+      - name: Rename jar to app.jar
+        run: |
+          mkdir -p deploy
+          cp build/libs/*.jar deploy/app.jar
+
+      - name: Copy app.jar to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.PROD_EC2_HOST }}
+          username: ${{ secrets.PROD_EC2_USER }}
+          key: ${{ secrets.PROD_EC2_KEY }}
+          source: "deploy/app.jar"
+          target: "/home/ubuntu/app"
+          strip_components: 1
+
+      - name: Restart Spring Boot app on EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.PROD_EC2_HOST }}
+          username: ${{ secrets.PROD_EC2_USER }}
+          key: ${{ secrets.PROD_EC2_KEY }}
+          script: |
+            bash -c '
+              source /home/ubuntu/env.sh
+              echo "SPRING_PROFILES_ACTIVE=$SPRING_PROFILES_ACTIVE"
+              cd /home/ubuntu/app
+
+              # 기존 프로세스 종료
+              PID=$(pgrep -f "app.jar")
+              if [ -n "$PID" ]; then
+                echo "Killing existing process: $PID"
+                kill -9 $PID
+              fi
+
+              # 새로운 프로세스 실행
+              nohup java -jar app.jar --spring.profiles.active=$SPRING_PROFILES_ACTIVE > app.log 2>&1 &
+            '


### PR DESCRIPTION
- `./gradlew clean bootJar` ->  `./gradlew clean build`: 테스트 진행하도록 수정
- dev cicd 파일 EC2_* -> DEV_EC2_*
- `name: Restart Spring Boot app on EC2` 단에서 기존 프로세스 종료문 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 개발 및 운영 환경에 대한 배포 워크플로우가 개선 및 추가되었습니다.
  * 운영 서버 배포 자동화가 도입되어, main 브랜치에 푸시 시 자동으로 Spring Boot 애플리케이션이 EC2에 배포되고, 기존 프로세스 종료 후 새로운 인스턴스가 실행됩니다.
  * 개발 환경 배포 시에도 기존 실행 중인 애플리케이션을 안전하게 종료 후 재시작하는 절차가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->