### PR TITLE
feature/soft-delete-retake-courses

### DIFF
--- a/src/main/java/com/chukchuk/haksa/application/portal/PortalSyncService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/PortalSyncService.java
@@ -2,6 +2,7 @@ package com.chukchuk.haksa.application.portal;
 
 import com.chukchuk.haksa.application.academic.dto.SyncAcademicRecordResult;
 import com.chukchuk.haksa.application.dto.ScrapingResponse;
+import com.chukchuk.haksa.domain.student.service.StudentService;
 import com.chukchuk.haksa.domain.user.model.User;
 import com.chukchuk.haksa.domain.user.service.UserService;
 import com.chukchuk.haksa.global.exception.ErrorCode;
@@ -23,6 +24,7 @@ public class PortalSyncService {
     private final RefreshPortalConnectionService refreshPortalConnectionService;
     private final SyncAcademicRecordService syncAcademicRecordService;
     private final UserService userService;
+    private final StudentService studentService;
 
     @Transactional
     public ScrapingResponse syncWithPortal(UUID userId, PortalData portalData) {
@@ -42,6 +44,8 @@ public class PortalSyncService {
         User user = userService.getUserById(userId);
         user.markPortalConnected(Instant.now());
         userService.save(user);
+
+        studentService.markReconnectedByUser(user);
 
         // 4. 응답 생성
         return new ScrapingResponse(UUID.randomUUID().toString(), portalConnectionResult.studentInfo());
@@ -65,6 +69,8 @@ public class PortalSyncService {
         User user = userService.getUserById(userId);
         user.updateLastSyncedAt(Instant.now());
         userService.save(user);
+
+        studentService.markReconnectedByUser(user);
 
         // 4. 응답 생성
         return new ScrapingResponse(UUID.randomUUID().toString(), portalConnectionResult.studentInfo());

--- a/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
+++ b/src/main/java/com/chukchuk/haksa/application/portal/SyncAcademicRecordService.java
@@ -115,8 +115,11 @@ public class SyncAcademicRecordService {
                 .toList();
 
         if (!toRemoveForRetake.isEmpty()) {
-            studentCourseRepository.deleteAllInBatch(toRemoveForRetake);
-            toRemoveForRetake.forEach(sc -> existingOfferingIds.remove(sc.getOffering().getId()));
+            toRemoveForRetake.forEach(sc -> {
+                sc.markDeletedForRetake(); // 플래그만 변경
+                existingOfferingIds.remove(sc.getOffering().getId());
+            });
+            studentCourseRepository.saveAll(toRemoveForRetake);
         }
 
 

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/dto/StudentCourseDto.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/dto/StudentCourseDto.java
@@ -23,7 +23,8 @@ public class StudentCourseDto {
             @Schema(description = "사이버 강의 여부") Boolean isOnline,
             @Schema(description = "이수 연도") Integer year,
             @Schema(description = "이수 학기") Integer semester,
-            @Schema(description = "원점수") Integer originalScore
+            @Schema(description = "원점수") Integer originalScore,
+            @Schema(description = "재수강 삭제 여부") boolean deletedForRetake
     ) {
         public static CourseDetailDto from(StudentCourse course) {
             return new CourseDetailDto(
@@ -39,7 +40,8 @@ public class StudentCourseDto {
                     Objects.requireNonNullElse(course.getOffering().getIsVideoLecture(), false),
                     course.getOffering().getYear(),
                     course.getOffering().getSemester(),
-                    course.getOriginalScore() != null ? course.getOriginalScore() : 0
+                    course.getOriginalScore() != null ? course.getOriginalScore() : 0,
+                    course.isDeletedForRetake()
             );
         }
     }

--- a/src/main/java/com/chukchuk/haksa/domain/academic/record/model/StudentCourse.java
+++ b/src/main/java/com/chukchuk/haksa/domain/academic/record/model/StudentCourse.java
@@ -40,6 +40,9 @@ public class StudentCourse {
     @Column(name = "created_at")
     private Instant createdAt;
 
+    @Column(nullable = false)
+    private boolean deletedForRetake = false;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "offering_id", nullable = false)
     private CourseOffering offering;
@@ -66,5 +69,9 @@ public class StudentCourse {
 
     public void setStudent(Student student) {
         this.student = student;
+    }
+
+    public void markDeletedForRetake() {
+        this.deletedForRetake = true;
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/course/repository/CourseOfferingRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/course/repository/CourseOfferingRepository.java
@@ -16,8 +16,9 @@ public interface CourseOfferingRepository extends JpaRepository<CourseOffering, 
       AND o.classSection = :classSection
       AND o.professor.id = :professorId
       AND o.facultyDivisionName = :facultyDivisionName
+      AND o.hostDepartment = :hostDepartment
 """)
-    Optional<CourseOffering> findByCourseIdAndYearAndSemesterAndClassSectionAndProfessorIdAndFacultyDivisionName(
-            Long courseId, Integer year, Integer semester, String classSection, Long professorId, FacultyDivision facultyDivisionName
+    Optional<CourseOffering> findByCourseIdAndYearAndSemesterAndClassSectionAndProfessorIdAndFacultyDivisionNameAndHostDepartment(
+            Long courseId, Integer year, Integer semester, String classSection, Long professorId, FacultyDivision facultyDivisionName, String hostDepartment
     );
 }

--- a/src/main/java/com/chukchuk/haksa/domain/course/service/CourseOfferingService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/course/service/CourseOfferingService.java
@@ -31,8 +31,8 @@ public class CourseOfferingService {
     @Transactional
     public CourseOffering getOrCreateOffering(CreateOfferingCommand cmd) {
         // 1. 존재하는지 확인
-        Optional<CourseOffering> existing = courseOfferingRepository.findByCourseIdAndYearAndSemesterAndClassSectionAndProfessorIdAndFacultyDivisionName(
-                cmd.courseId(), cmd.year(), cmd.semester(), cmd.classSection(), cmd.professorId(), FacultyDivision.valueOf(cmd.facultyDivisionName())
+        Optional<CourseOffering> existing = courseOfferingRepository.findByCourseIdAndYearAndSemesterAndClassSectionAndProfessorIdAndFacultyDivisionNameAndHostDepartment(
+                cmd.courseId(), cmd.year(), cmd.semester(), cmd.classSection(), cmd.professorId(), FacultyDivision.valueOf(cmd.facultyDivisionName()), cmd.hostDepartment()
         );
 
         if (existing.isPresent()) return existing.get();

--- a/src/main/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/graduation/repository/GraduationQueryRepository.java
@@ -59,6 +59,7 @@ public class GraduationQueryRepository {
         JOIN courses c ON co.course_id = c.id
         WHERE sc.grade NOT IN ('F', 'R')
           AND sc.student_id = :studentId
+          AND sc.deleted_for_retake = false
         ORDER BY c.course_code, sc.original_score DESC
     ),
     area_requirements AS (

--- a/src/main/java/com/chukchuk/haksa/domain/student/dto/StudentDto.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/dto/StudentDto.java
@@ -17,7 +17,8 @@ public class StudentDto {
             Integer gradeLevel,
             StudentStatus status,
             Integer completedSemesters,
-            Instant updatedAt
+            Instant updatedAt,
+            boolean reconnectionRequired
     ) {
         public static StudentInfoDto from(Student student) {
             return new StudentInfoDto(
@@ -28,7 +29,8 @@ public class StudentDto {
                     student.getAcademicInfo().getGradeLevel(),
                     student.getAcademicInfo().getStatus(),
                     student.getAcademicInfo().getCompletedSemesters(),
-                    student.getUpdatedAt()
+                    student.getUpdatedAt(),
+                    student.isReconnectionRequired()
             );
         }
     }
@@ -43,7 +45,8 @@ public class StudentDto {
             @Schema(description = "현재 학기", required = true) int currentSemester,
             @Schema(description = "재학 상태", required = true, implementation = StudentStatus.class) StudentStatus status,
             @Schema(description = "마지막 업데이트 일시", required = true) String lastUpdatedAt,
-            @Schema(description = "학사 정보 마지막 연동 일시", required = true) String lastSyncedAt
+            @Schema(description = "학사 정보 마지막 연동 일시", required = true) String lastSyncedAt,
+            @Schema(description = "재연동 필요 여부", required = true) boolean reconnectionRequired
     ) {
         public static StudentProfileResponse from(StudentDto.StudentInfoDto studentInfoDto, int currentSemester, String lastSyncedAt) {
             return new StudentProfileResponse(
@@ -55,7 +58,8 @@ public class StudentDto {
                     currentSemester,
                     studentInfoDto.status(),
                     studentInfoDto.updatedAt().toString(),
-                    lastSyncedAt
+                    lastSyncedAt,
+                    studentInfoDto.reconnectionRequired()
             );
         }
     }

--- a/src/main/java/com/chukchuk/haksa/domain/student/model/Student.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/model/Student.java
@@ -46,6 +46,9 @@ public class Student extends BaseEntity {
     @Column(name = "target_gpa")
     private Double targetGpa;
 
+    @Column(nullable = false)
+    private boolean reconnectionRequired = true; // 기본값 true, 재연동 시 false
+
     @Embedded
     private AcademicInfo academicInfo;
 

--- a/src/main/java/com/chukchuk/haksa/domain/student/model/Student.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/model/Student.java
@@ -46,7 +46,7 @@ public class Student extends BaseEntity {
     @Column(name = "target_gpa")
     private Double targetGpa;
 
-    @Column(nullable = false)
+    @Column(name = "reconnection_required", nullable = false)
     private boolean reconnectionRequired = true; // 기본값 true, 재연동 시 false
 
     @Embedded
@@ -198,5 +198,9 @@ public class Student extends BaseEntity {
 
     private boolean equalsNullable(Object a, Object b) {
         return java.util.Objects.equals(a, b);
+    }
+
+    public void markReconnected() {
+        this.reconnectionRequired = false;
     }
 }

--- a/src/main/java/com/chukchuk/haksa/domain/student/repository/StudentRepository.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/repository/StudentRepository.java
@@ -1,12 +1,15 @@
 package com.chukchuk.haksa.domain.student.repository;
 
 import com.chukchuk.haksa.domain.student.model.Student;
+import com.chukchuk.haksa.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface StudentRepository extends JpaRepository<Student, UUID> {
+    Optional<Student> findByUser(User user);
 
 }

--- a/src/main/java/com/chukchuk/haksa/domain/student/service/StudentService.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/service/StudentService.java
@@ -34,6 +34,14 @@ public class StudentService {
     }
 
     @Transactional
+    public void markReconnectedByUser(User user) {
+        Student student = studentRepository.findByUser(user)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.STUDENT_NOT_FOUND));
+        student.markReconnected();
+        studentRepository.save(student);
+    }
+
+    @Transactional
     public void save(Student student) {
         studentRepository.save(student);
     }

--- a/src/main/java/com/chukchuk/haksa/domain/student/wrapper/StudentProfileApiResponse.java
+++ b/src/main/java/com/chukchuk/haksa/domain/student/wrapper/StudentProfileApiResponse.java
@@ -19,7 +19,8 @@ public class StudentProfileApiResponse extends SuccessResponse<StudentProfileRes
                 6,                        // currentSemester
                 StudentStatus.재학,               // status
                 "2024-04-25T10:00:00Z",    // lastUpdatedAt
-                "2024-04-25T08:00:00Z"     // lastSyncedAt
+                "2024-04-25T08:00:00Z",     // lastSyncedAt
+                true
         ), "요청 성공");
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 학생 프로필에 ‘포털 재연동 필요’ 여부가 표시됩니다.

- 개선
  - 포털 동기화/새로고침 후 ‘재연동 필요’ 상태가 자동으로 해제됩니다.
  - 재수강으로 대체된 수강 기록을 소프트 삭제로 보관하고, 졸업 진도/학점 집계에서 제외합니다.
  - 개설강좌 조회에 주관학과 조건이 추가되어 중복 생성·매칭 정확도가 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->